### PR TITLE
fix parse error, removed line in header.html

### DIFF
--- a/docs_source_files/content/driver_idiosyncrasies/shared_capabilities.fr.md
+++ b/docs_source_files/content/driver_idiosyncrasies/shared_capabilities.fr.md
@@ -22,8 +22,8 @@ The page load strategy queries the
 [document.readyState](//developer.mozilla.org/en-US/docs/Web/API/Document/readyState)
 as described in the table below:
 
-| Strategy | Ready State | Notes                                                                     |
-| -------- | ----------- | ------------------------------------------------------------------------- |
-| normal   | complete    | Used by default, waits for all resources to download                      |
-| eager    | interactive | DOM access is ready, but other resources like images may still be loading |
-| none     | Any         | Does not block WebDriver at all                                           |
+| Strategy | Ready State | Notes |
+| -------- | ----------- | ----- |
+| normal | complete | Used by default, waits for all resources to download |
+| eager | interactive | DOM access is ready, but other resources like images may still be loading |
+| none | Any | Does not block WebDriver at all |

--- a/docs_source_files/content/front_matter/copyright_and_attributions.es.md
+++ b/docs_source_files/content/front_matter/copyright_and_attributions.es.md
@@ -57,11 +57,11 @@ to the use of the information contained herein.
 
 ## Third-Party software used by Selenium documentation project:
 
-| Software                                                 | Version | License                                                               |
-| -------------------------------------------------------- | ------- | --------------------------------------------------------------------- |
-| [Hugo](//gohugo.io/)                                     | v0.55.6 | [Apache 2.0](//gohugo.io/about/license/)                              |
-| [Hugo Learn Theme](//themes.gohugo.io/hugo-theme-learn/) | v2.3.0  | [MIT](//github.com/matcornic/hugo-theme-learn/blob/master/LICENSE.md) |
-| [Code Tabs Style](//codepen.io/markcaron/pen/MvGRYV)     | ---     | [MIT](//blog.codepen.io/legal/licensing/)                             |
+| Software | Version | License |
+| -------- | ------- | ------- |
+| [Hugo](//gohugo.io/) | v0.55.6 | [Apache 2.0](//gohugo.io/about/license/) |
+| [Hugo Learn Theme](//themes.gohugo.io/hugo-theme-learn/) | v2.3.0 | [MIT](//github.com/matcornic/hugo-theme-learn/blob/master/LICENSE.md) |
+| [Code Tabs Style](//codepen.io/markcaron/pen/MvGRYV) | --- | [MIT](//blog.codepen.io/legal/licensing/) |
 
 
 ## HTML version and source code

--- a/docs_source_files/content/front_matter/copyright_and_attributions.fr.md
+++ b/docs_source_files/content/front_matter/copyright_and_attributions.fr.md
@@ -56,11 +56,11 @@ to the use of the information contained herein.
 
 ## Third-Party software used by Selenium documentation project:
 
-| Software                                                 | Version | License                                                               |
-| -------------------------------------------------------- | ------- | --------------------------------------------------------------------- |
-| [Hugo](//gohugo.io/)                                     | v0.55.6 | [Apache 2.0](//gohugo.io/about/license/)                              |
-| [Hugo Learn Theme](//themes.gohugo.io/hugo-theme-learn/) | v2.3.0  | [MIT](//github.com/matcornic/hugo-theme-learn/blob/master/LICENSE.md) |
-| [Code Tabs Style](//codepen.io/markcaron/pen/MvGRYV)     | ---     | [MIT](//blog.codepen.io/legal/licensing/)                             |
+| Software | Version | License |
+| -------- | ------- | ------- |
+| [Hugo](//gohugo.io/) | v0.55.6 | [Apache 2.0](//gohugo.io/about/license/) |
+| [Hugo Learn Theme](//themes.gohugo.io/hugo-theme-learn/) | v2.3.0 | [MIT](//github.com/matcornic/hugo-theme-learn/blob/master/LICENSE.md) |
+| [Code Tabs Style](//codepen.io/markcaron/pen/MvGRYV) | --- | [MIT](//blog.codepen.io/legal/licensing/) |
 
 
 ## HTML version and source code

--- a/docs_source_files/content/front_matter/copyright_and_attributions.nl.md
+++ b/docs_source_files/content/front_matter/copyright_and_attributions.nl.md
@@ -62,11 +62,11 @@ to the use of the information contained herein.
 
 ## Third-Party software used by Selenium documentation project:
 
-| Software                                                 | Version | License                                                               |
-| -------------------------------------------------------- | ------- | --------------------------------------------------------------------- |
-| [Hugo](//gohugo.io/)                                     | v0.55.6 | [Apache 2.0](//gohugo.io/about/license/)                              |
-| [Hugo Learn Theme](//themes.gohugo.io/hugo-theme-learn/) | v2.3.0  | [MIT](//github.com/matcornic/hugo-theme-learn/blob/master/LICENSE.md) |
-| [Code Tabs Style](//codepen.io/markcaron/pen/MvGRYV)     | ---     | [MIT](//blog.codepen.io/legal/licensing/)                             |
+| Software | Version | License |
+| -------- | ------- | ------- |
+| [Hugo](//gohugo.io/) | v0.55.6 | [Apache 2.0](//gohugo.io/about/license/) |
+| [Hugo Learn Theme](//themes.gohugo.io/hugo-theme-learn/) | v2.3.0 | [MIT](//github.com/matcornic/hugo-theme-learn/blob/master/LICENSE.md) |
+| [Code Tabs Style](//codepen.io/markcaron/pen/MvGRYV) | --- | [MIT](//blog.codepen.io/legal/licensing/) |
 
 
 ## HTML version and source code

--- a/docs_source_files/content/grid/_index.fr.md
+++ b/docs_source_files/content/grid/_index.fr.md
@@ -21,13 +21,13 @@ one server acts as the hub that routes JSON formatted test commands
 to one or more registered Grid nodes.
 Tests contact the hub to obtain access to remote browser instances.
 The hub has a list of registered servers that it provides access to,
-and allows us to control these instances.
+and allows control of these instances.
 
 Selenium Grid allows us to run tests in parallel on multiple machines,
 and to manage different browser versions and browser configurations centrally
 (instead of in each individual test).
 
-Selenium Grid isn't a silver bullet.
+Selenium Grid is not a silver bullet.
 It solves a subset of common delegation and distribution problems,
-but will for example not manage your infrastructure
+but will for example not manage your infrastructure,
 and might not suit your specific needs.

--- a/docs_source_files/content/grid/_index.nl.md
+++ b/docs_source_files/content/grid/_index.nl.md
@@ -21,13 +21,13 @@ one server acts as the hub that routes JSON formatted test commands
 to one or more registered Grid nodes.
 Tests contact the hub to obtain access to remote browser instances.
 The hub has a list of registered servers that it provides access to,
-and allows us to control these instances.
+and allows control of these instances.
 
 Selenium Grid allows us to run tests in parallel on multiple machines,
 and to manage different browser versions and browser configurations centrally
 (instead of in each individual test).
 
-Selenium Grid isn't a silver bullet.
+Selenium Grid is not a silver bullet.
 It solves a subset of common delegation and distribution problems,
-but will for example not manage your infrastructure
+but will for example not manage your infrastructure,
 and might not suit your specific needs.

--- a/docs_source_files/content/grid/components_of_a_grid.fr.md
+++ b/docs_source_files/content/grid/components_of_a_grid.fr.md
@@ -17,7 +17,7 @@ it by sending us pull requests!
 * Takes instructions from client and executes them remotely on the nodes
 * Manages threads
 
-A _Hub_ is a central point where all your tests are sent to.
+A _Hub_ is a central point where all your tests are sent.
 Each Selenium Grid consists of exactly one hub. The hub needs to be reachable
 from the respective clients (i.e. CI server, Developer machine etc.)
 The hub will connect one or more nodes
@@ -25,14 +25,14 @@ that tests will be delegated to.
 
 ## Nodes
 
-* This is where the browsers live
+* Where the browsers live
 * Registers itself to the hub and communicates its capabilities
 * Receives requests from the hub and executes them
 
 _Nodes_ are different Selenium instances
 that will execute tests on individual computer systems.
 There can be many nodes in a grid.
-The machines which are nodes need do not need to be the same platform
+The machines which are nodes do not need to be the same platform
 or have the same browser selection as that of the hub or the other nodes.
 A node on Windows might have the capability of
 offering Internet Explorer as a browser option,

--- a/docs_source_files/content/grid/components_of_a_grid.ja.md
+++ b/docs_source_files/content/grid/components_of_a_grid.ja.md
@@ -16,7 +16,7 @@ weight: 2
 * Takes instructions from client and executes them remotely on the nodes
 * Manages threads
 
-A _Hub_ is a central point where all your tests are sent to.
+A _Hub_ is a central point where all your tests are sent.
 Each Selenium Grid consists of exactly one hub. The hub needs to be reachable
 from the respective clients (i.e. CI server, Developer machine etc.)
 The hub will connect one or more nodes
@@ -24,15 +24,16 @@ that tests will be delegated to.
 
 ## Nodes
 
-* This is where the browsers live
+* Where the browsers live
 * Registers itself to the hub and communicates its capabilities
 * Receives requests from the hub and executes them
 
 _Nodes_ are different Selenium instances
 that will execute tests on individual computer systems.
 There can be many nodes in a grid.
-The machines which are nodes need do not need to be the same platform
+The machines which are nodes do not need to be the same platform
 or have the same browser selection as that of the hub or the other nodes.
 A node on Windows might have the capability of
 offering Internet Explorer as a browser option,
 whereas this wouldn't be possible on Linux or Mac.
+

--- a/docs_source_files/content/grid/components_of_a_grid.nl.md
+++ b/docs_source_files/content/grid/components_of_a_grid.nl.md
@@ -17,7 +17,7 @@ it by sending us pull requests!
 * Takes instructions from client and executes them remotely on the nodes
 * Manages threads
 
-A _Hub_ is a central point where all your tests are sent to.
+A _Hub_ is a central point where all your tests are sent.
 Each Selenium Grid consists of exactly one hub. The hub needs to be reachable
 from the respective clients (i.e. CI server, Developer machine etc.)
 The hub will connect one or more nodes
@@ -25,14 +25,14 @@ that tests will be delegated to.
 
 ## Nodes
 
-* This is where the browsers live
+* Where the browsers live
 * Registers itself to the hub and communicates its capabilities
 * Receives requests from the hub and executes them
 
 _Nodes_ are different Selenium instances
 that will execute tests on individual computer systems.
 There can be many nodes in a grid.
-The machines which are nodes need do not need to be the same platform
+The machines which are nodes do not need to be the same platform
 or have the same browser selection as that of the hub or the other nodes.
 A node on Windows might have the capability of
 offering Internet Explorer as a browser option,

--- a/docs_source_files/content/grid/components_of_a_grid.zh-cn.md
+++ b/docs_source_files/content/grid/components_of_a_grid.zh-cn.md
@@ -16,7 +16,7 @@ weight: 2
 * Takes instructions from client and executes them remotely on the nodes
 * Manages threads
 
-A _Hub_ is a central point where all your tests are sent to.
+A _Hub_ is a central point where all your tests are sent.
 Each Selenium Grid consists of exactly one hub. The hub needs to be reachable
 from the respective clients (i.e. CI server, Developer machine etc.)
 The hub will connect one or more nodes
@@ -24,14 +24,14 @@ that tests will be delegated to.
 
 ## Nodes
 
-* This is where the browsers live
+* Where the browsers live
 * Registers itself to the hub and communicates its capabilities
 * Receives requests from the hub and executes them
 
 _Nodes_ are different Selenium instances
 that will execute tests on individual computer systems.
 There can be many nodes in a grid.
-The machines which are nodes need do not need to be the same platform
+The machines which are nodes do not need to be the same platform
 or have the same browser selection as that of the hub or the other nodes.
 A node on Windows might have the capability of
 offering Internet Explorer as a browser option,

--- a/docs_source_files/content/grid/purposes_and_main_functionalities.fr.md
+++ b/docs_source_files/content/grid/purposes_and_main_functionalities.fr.md
@@ -11,7 +11,7 @@ it by sending us pull requests!
 {{% /notice %}}
 
 * Central entry point for all tests
-* Management and control of the nodes / environment where the browsers run on
+* Management and control of the nodes / environment where the browsers run
 * Scaling
 * Running tests in parallel
 * Cross platform testing

--- a/docs_source_files/content/grid/purposes_and_main_functionalities.ja.md
+++ b/docs_source_files/content/grid/purposes_and_main_functionalities.ja.md
@@ -10,7 +10,7 @@ weight: 1
 {{% /notice %}}
 
 * Central entry point for all tests
-* Management and control of the nodes / environment where the browsers run on
+* Management and control of the nodes / environment where the browsers run
 * Scaling
 * Running tests in parallel
 * Cross platform testing

--- a/docs_source_files/content/grid/purposes_and_main_functionalities.nl.md
+++ b/docs_source_files/content/grid/purposes_and_main_functionalities.nl.md
@@ -11,7 +11,7 @@ it by sending us pull requests!
 {{% /notice %}}
 
 * Central entry point for all tests
-* Management and control of the nodes / environment where the browsers run on
+* Management and control of the nodes / environment where the browsers run
 * Scaling
 * Running tests in parallel
 * Cross platform testing

--- a/docs_source_files/content/grid/purposes_and_main_functionalities.zh-cn.md
+++ b/docs_source_files/content/grid/purposes_and_main_functionalities.zh-cn.md
@@ -10,7 +10,7 @@ weight: 1
 {{% /notice %}}
 
 * Central entry point for all tests
-* Management and control of the nodes / environment where the browsers run on
+* Management and control of the nodes / environment where the browsers run
 * Scaling
 * Running tests in parallel
 * Cross platform testing

--- a/docs_source_files/content/grid/setting_up_your_own_grid.fr.md
+++ b/docs_source_files/content/grid/setting_up_your_own_grid.fr.md
@@ -27,7 +27,7 @@ complete with its own node infrastructure.
 
 This example will show you how to start the Selenium 2 Grid Hub,
 and register both a WebDriver node and a Selenium 1 RC legacy node.
-We’ll also show you how to call the grid from Java.
+We will also show you how to call the grid from Java.
 The hub and nodes are shown here running on the same machine,
 but of course you can copy the selenium-server-standalone to multiple machines.
 
@@ -72,7 +72,7 @@ are possible command-line flags.
 
 You certainly can get by with only the simple command shown above,
 but if you need more advanced configuration,
-then you may also for convenience specify a JSON format config file
+you can also specify a JSON format config file, for convenience,
 to configure the hub when you start it.
 You can do it like so:
 
@@ -198,26 +198,26 @@ hub/node to be reachable from a different machine.
 #### Specifying the port
 
 The default TCP/IP port used by the hub is 4444. If you need to change the port 
-please use above mentioned configurations
+please use above mentioned configurations.
 
 ## Troubleshooting
 
 ### Using Log file
-For advance troubleshooting you can specify log file to log system messages.
-For that start Selenium GRID hub or node with -log argument. Please see the below example
+For advanced troubleshooting you can specify a log file to log system messages.
+Start Selenium GRID hub or node with -log argument. Please see the below example:
 
 ```shell
 java -jar selenium-server-standalone.jar -role hub -log log.txt
 ```
 
-Use your favorite text editor to open log file (log.txt in above example) to find 
+Use your favorite text editor to open log file (log.txt in the example above) to find 
 "ERROR" logs if you get issues.
 
 ### Using `-debug` argument
 
-Also you can use `-debug` argument to print debug logs on console.
-For that start Selenium Grid Hub or Node with `-debug` argument. Please see 
-the below example
+Also you can use `-debug` argument to print debug logs to console.
+Start Selenium Grid Hub or Node with `-debug` argument. Please see 
+the below example:
 
 ```shell
 java -jar selenium-server-standalone.jar -role hub -debug
@@ -229,11 +229,12 @@ The Selenium Grid must be protected from external access using appropriate
 firewall permissions.
 
 Failure to protect your Grid could result in one or more of the following occurring:
-* You provide open access to your Grid infrastructure
-* You allow 3rd parties to access internal web applications and files
-* You allow 3rd parties to run custom binaries
 
-See this blog post on [Detectify](//labs.detectify.com) which gives a good 
+* You provide open access to your Grid infrastructure
+* You allow third parties to access internal web applications and files
+* You allow third parties to run custom binaries
+
+See this blog post on [Detectify](//labs.detectify.com), which gives a good 
 overview of how a publicly exposed Grid could be misused: 
 [Don't Leave your Grid Wide Open](//labs.detectify.com/2017/10/06/guest-blog-dont-leave-your-grid-wide-open/).
 
@@ -242,7 +243,7 @@ overview of how a publicly exposed Grid could be misused:
 [Docker](//www.docker.com/) provides a convenient way to
 provision and scale Selenium Grid infrastructure in a unit known as a container.
 Containers are standardised units of software that contain everything required
-to run the desired application including all dependencies in a reliable and repeatable
+to run the desired application, including all dependencies, in a reliable and repeatable
 way on different machines.
 
 The Selenium project maintains a set of Docker images which you can download

--- a/docs_source_files/content/grid/setting_up_your_own_grid.ja.md
+++ b/docs_source_files/content/grid/setting_up_your_own_grid.ja.md
@@ -26,12 +26,12 @@ complete with its own node infrastructure.
 
 This example will show you how to start the Selenium 2 Grid Hub,
 and register both a WebDriver node and a Selenium 1 RC legacy node.
-We’ll also show you how to call the grid from Java.
+We will also show you how to call the grid from Java.
 The hub and nodes are shown here running on the same machine,
 but of course you can copy the selenium-server-standalone to multiple machines.
 
 The `selenium-server-standalone` package includes the hub,
-WebDriver, and legacy RC needed to run the Grid,
+WebDriver, and legacy RC needed to run the Grid, 
 _ant_ is not required anymore.
 You can download the `selenium-server-standalone-.jar` from
 [http://www.seleniumhq.org/download/](http://www.seleniumhq.org/download/).
@@ -71,7 +71,7 @@ are possible command-line flags.
 
 You certainly can get by with only the simple command shown above,
 but if you need more advanced configuration,
-then you may also for convenience specify a JSON format config file
+you can also specify a JSON format config file, for convenience,
 to configure the hub when you start it.
 You can do it like so:
 
@@ -196,27 +196,27 @@ hub/node to be reachable from a different machine.
 
 #### Specifying the port
 
-The default TCP/IP port used by the hub is 4444. If you need to change the port
-please use above mentioned configurations
+The default TCP/IP port used by the hub is 4444. If you need to change the port 
+please use above mentioned configurations.
 
 ## Troubleshooting
 
 ### Using Log file
-For advance troubleshooting you can specify log file to log system messages.
-For that start Selenium GRID hub or node with -log argument. Please see the below example
+For advanced troubleshooting you can specify a log file to log system messages.
+Start Selenium GRID hub or node with -log argument. Please see the below example:
 
 ```shell
 java -jar selenium-server-standalone.jar -role hub -log log.txt
 ```
 
-Use your favorite text editor to open log file (log.txt in above example) to find
+Use your favorite text editor to open log file (log.txt in the example above) to find 
 "ERROR" logs if you get issues.
 
 ### Using `-debug` argument
 
-Also you can use `-debug` argument to print debug logs on console.
-For that start Selenium Grid Hub or Node with `-debug` argument. Please see
-the below example
+Also you can use `-debug` argument to print debug logs to console.
+Start Selenium Grid Hub or Node with `-debug` argument. Please see 
+the below example:
 
 ```shell
 java -jar selenium-server-standalone.jar -role hub -debug
@@ -228,12 +228,13 @@ The Selenium Grid must be protected from external access using appropriate
 firewall permissions.
 
 Failure to protect your Grid could result in one or more of the following occurring:
-* You provide open access to your Grid infrastructure
-* You allow 3rd parties to access internal web applications and files
-* You allow 3rd parties to run custom binaries
 
-See this blog post on [Detectify](//labs.detectify.com) which gives a good
-overview of how a publicly exposed Grid could be misused:
+* You provide open access to your Grid infrastructure
+* You allow third parties to access internal web applications and files
+* You allow third parties to run custom binaries
+
+See this blog post on [Detectify](//labs.detectify.com), which gives a good 
+overview of how a publicly exposed Grid could be misused: 
 [Don't Leave your Grid Wide Open](//labs.detectify.com/2017/10/06/guest-blog-dont-leave-your-grid-wide-open/).
 
 
@@ -241,13 +242,13 @@ overview of how a publicly exposed Grid could be misused:
 [Docker](//www.docker.com/) provides a convenient way to
 provision and scale Selenium Grid infrastructure in a unit known as a container.
 Containers are standardised units of software that contain everything required
-to run the desired application including all dependencies in a reliable and repeatable
+to run the desired application, including all dependencies, in a reliable and repeatable
 way on different machines.
 
 The Selenium project maintains a set of Docker images which you can download
 and run to get a working grid up and running quickly. Nodes are available for
 both Firefox and Chrome. Full details of how to provision a grid can be found
-within the [Docker Selenium](//github.com/SeleniumHQ/docker-selenium)
+within the [Docker Selenium](//github.com/SeleniumHQ/docker-selenium) 
 repository.
 
 ### Prerequisite

--- a/docs_source_files/content/grid/setting_up_your_own_grid.nl.md
+++ b/docs_source_files/content/grid/setting_up_your_own_grid.nl.md
@@ -27,7 +27,7 @@ complete with its own node infrastructure.
 
 This example will show you how to start the Selenium 2 Grid Hub,
 and register both a WebDriver node and a Selenium 1 RC legacy node.
-We’ll also show you how to call the grid from Java.
+We will also show you how to call the grid from Java.
 The hub and nodes are shown here running on the same machine,
 but of course you can copy the selenium-server-standalone to multiple machines.
 
@@ -72,7 +72,7 @@ are possible command-line flags.
 
 You certainly can get by with only the simple command shown above,
 but if you need more advanced configuration,
-then you may also for convenience specify a JSON format config file
+you can also specify a JSON format config file, for convenience,
 to configure the hub when you start it.
 You can do it like so:
 
@@ -198,26 +198,26 @@ hub/node to be reachable from a different machine.
 #### Specifying the port
 
 The default TCP/IP port used by the hub is 4444. If you need to change the port 
-please use above mentioned configurations
+please use above mentioned configurations.
 
 ## Troubleshooting
 
 ### Using Log file
-For advance troubleshooting you can specify log file to log system messages.
-For that start Selenium GRID hub or node with -log argument. Please see the below example
+For advanced troubleshooting you can specify a log file to log system messages.
+Start Selenium GRID hub or node with -log argument. Please see the below example:
 
 ```shell
 java -jar selenium-server-standalone.jar -role hub -log log.txt
 ```
 
-Use your favorite text editor to open log file (log.txt in above example) to find 
+Use your favorite text editor to open log file (log.txt in the example above) to find 
 "ERROR" logs if you get issues.
 
 ### Using `-debug` argument
 
-Also you can use `-debug` argument to print debug logs on console.
-For that start Selenium Grid Hub or Node with `-debug` argument. Please see 
-the below example
+Also you can use `-debug` argument to print debug logs to console.
+Start Selenium Grid Hub or Node with `-debug` argument. Please see 
+the below example:
 
 ```shell
 java -jar selenium-server-standalone.jar -role hub -debug
@@ -229,11 +229,12 @@ The Selenium Grid must be protected from external access using appropriate
 firewall permissions.
 
 Failure to protect your Grid could result in one or more of the following occurring:
-* You provide open access to your Grid infrastructure
-* You allow 3rd parties to access internal web applications and files
-* You allow 3rd parties to run custom binaries
 
-See this blog post on [Detectify](//labs.detectify.com) which gives a good 
+* You provide open access to your Grid infrastructure
+* You allow third parties to access internal web applications and files
+* You allow third parties to run custom binaries
+
+See this blog post on [Detectify](//labs.detectify.com), which gives a good 
 overview of how a publicly exposed Grid could be misused: 
 [Don't Leave your Grid Wide Open](//labs.detectify.com/2017/10/06/guest-blog-dont-leave-your-grid-wide-open/).
 
@@ -242,7 +243,7 @@ overview of how a publicly exposed Grid could be misused:
 [Docker](//www.docker.com/) provides a convenient way to
 provision and scale Selenium Grid infrastructure in a unit known as a container.
 Containers are standardised units of software that contain everything required
-to run the desired application including all dependencies in a reliable and repeatable
+to run the desired application, including all dependencies, in a reliable and repeatable
 way on different machines.
 
 The Selenium project maintains a set of Docker images which you can download

--- a/docs_source_files/content/grid/setting_up_your_own_grid.zh-cn.md
+++ b/docs_source_files/content/grid/setting_up_your_own_grid.zh-cn.md
@@ -26,12 +26,12 @@ complete with its own node infrastructure.
 
 This example will show you how to start the Selenium 2 Grid Hub,
 and register both a WebDriver node and a Selenium 1 RC legacy node.
-We’ll also show you how to call the grid from Java.
+We will also show you how to call the grid from Java.
 The hub and nodes are shown here running on the same machine,
 but of course you can copy the selenium-server-standalone to multiple machines.
 
 The `selenium-server-standalone` package includes the hub,
-WebDriver, and legacy RC needed to run the Grid,
+WebDriver, and legacy RC needed to run the Grid, 
 _ant_ is not required anymore.
 You can download the `selenium-server-standalone-.jar` from
 [http://www.seleniumhq.org/download/](http://www.seleniumhq.org/download/).
@@ -71,7 +71,7 @@ are possible command-line flags.
 
 You certainly can get by with only the simple command shown above,
 but if you need more advanced configuration,
-then you may also for convenience specify a JSON format config file
+you can also specify a JSON format config file, for convenience,
 to configure the hub when you start it.
 You can do it like so:
 
@@ -196,27 +196,27 @@ hub/node to be reachable from a different machine.
 
 #### Specifying the port
 
-The default TCP/IP port used by the hub is 4444. If you need to change the port
-please use above mentioned configurations
+The default TCP/IP port used by the hub is 4444. If you need to change the port 
+please use above mentioned configurations.
 
 ## Troubleshooting
 
 ### Using Log file
-For advance troubleshooting you can specify log file to log system messages.
-For that start Selenium GRID hub or node with -log argument. Please see the below example
+For advanced troubleshooting you can specify a log file to log system messages.
+Start Selenium GRID hub or node with -log argument. Please see the below example:
 
 ```shell
 java -jar selenium-server-standalone.jar -role hub -log log.txt
 ```
 
-Use your favorite text editor to open log file (log.txt in above example) to find
+Use your favorite text editor to open log file (log.txt in the example above) to find 
 "ERROR" logs if you get issues.
 
 ### Using `-debug` argument
 
-Also you can use `-debug` argument to print debug logs on console.
-For that start Selenium Grid Hub or Node with `-debug` argument. Please see
-the below example
+Also you can use `-debug` argument to print debug logs to console.
+Start Selenium Grid Hub or Node with `-debug` argument. Please see 
+the below example:
 
 ```shell
 java -jar selenium-server-standalone.jar -role hub -debug
@@ -228,12 +228,13 @@ The Selenium Grid must be protected from external access using appropriate
 firewall permissions.
 
 Failure to protect your Grid could result in one or more of the following occurring:
-* You provide open access to your Grid infrastructure
-* You allow 3rd parties to access internal web applications and files
-* You allow 3rd parties to run custom binaries
 
-See this blog post on [Detectify](//labs.detectify.com) which gives a good
-overview of how a publicly exposed Grid could be misused:
+* You provide open access to your Grid infrastructure
+* You allow third parties to access internal web applications and files
+* You allow third parties to run custom binaries
+
+See this blog post on [Detectify](//labs.detectify.com), which gives a good 
+overview of how a publicly exposed Grid could be misused: 
 [Don't Leave your Grid Wide Open](//labs.detectify.com/2017/10/06/guest-blog-dont-leave-your-grid-wide-open/).
 
 
@@ -241,13 +242,13 @@ overview of how a publicly exposed Grid could be misused:
 [Docker](//www.docker.com/) provides a convenient way to
 provision and scale Selenium Grid infrastructure in a unit known as a container.
 Containers are standardised units of software that contain everything required
-to run the desired application including all dependencies in a reliable and repeatable
+to run the desired application, including all dependencies, in a reliable and repeatable
 way on different machines.
 
 The Selenium project maintains a set of Docker images which you can download
 and run to get a working grid up and running quickly. Nodes are available for
 both Firefox and Chrome. Full details of how to provision a grid can be found
-within the [Docker Selenium](//github.com/SeleniumHQ/docker-selenium)
+within the [Docker Selenium](//github.com/SeleniumHQ/docker-selenium) 
 repository.
 
 ### Prerequisite

--- a/docs_source_files/content/guidelines_and_recommendations/_index.es.md
+++ b/docs_source_files/content/guidelines_and_recommendations/_index.es.md
@@ -15,17 +15,17 @@ it by sending us pull requests!
 
 A note on "Best Practices": We've intentionally avoided the phrase "Best
 Practices" in this documentation. No one approach works for all situations.
-We prefer the idea of "Guidelines and Recommendations." We encourage
+We prefer the idea of "Guidelines and Recommendations". We encourage
 you to read through these and thoughtfully decide what approaches
 will work for you in your particular environment.
 
 Functional testing is difficult to get right for many reasons.
-As if application state, complexity, and dependencies don't make testing difficult enough,
+As if application state, complexity, and dependencies do not make testing difficult enough,
 dealing with browsers (especially with cross-browser incompatibilities)
 makes writing good tests a challenge.
 
 Selenium provides tools to make functional user interaction easier,
-but doesn't help you write well-architected test suites.
+but does not help you write well-architected test suites.
 In this chapter we offer advice, guidelines, and recommendations.
 on how to approach functional web page automation.
 

--- a/docs_source_files/content/guidelines_and_recommendations/_index.fr.md
+++ b/docs_source_files/content/guidelines_and_recommendations/_index.fr.md
@@ -15,17 +15,17 @@ it by sending us pull requests!
 
 A note on "Best Practices": We've intentionally avoided the phrase "Best
 Practices" in this documentation. No one approach works for all situations.
-We prefer the idea of "Guidelines and Recommendations." We encourage
+We prefer the idea of "Guidelines and Recommendations". We encourage
 you to read through these and thoughtfully decide what approaches
 will work for you in your particular environment.
 
 Functional testing is difficult to get right for many reasons.
-As if application state, complexity, and dependencies don't make testing difficult enough,
+As if application state, complexity, and dependencies do not make testing difficult enough,
 dealing with browsers (especially with cross-browser incompatibilities)
 makes writing good tests a challenge.
 
 Selenium provides tools to make functional user interaction easier,
-but doesn't help you write well-architected test suites.
+but does not help you write well-architected test suites.
 In this chapter we offer advice, guidelines, and recommendations.
 on how to approach functional web page automation.
 

--- a/docs_source_files/content/guidelines_and_recommendations/_index.ja.md
+++ b/docs_source_files/content/guidelines_and_recommendations/_index.ja.md
@@ -14,17 +14,17 @@ weight: 7
 
 A note on "Best Practices": We've intentionally avoided the phrase "Best
 Practices" in this documentation. No one approach works for all situations.
-We prefer the idea of "Guidelines and Recommendations." We encourage
+We prefer the idea of "Guidelines and Recommendations". We encourage
 you to read through these and thoughtfully decide what approaches
 will work for you in your particular environment.
 
 Functional testing is difficult to get right for many reasons.
-As if application state, complexity, and dependencies don't make testing difficult enough,
+As if application state, complexity, and dependencies do not make testing difficult enough,
 dealing with browsers (especially with cross-browser incompatibilities)
 makes writing good tests a challenge.
 
 Selenium provides tools to make functional user interaction easier,
-but doesn't help you write well-architected test suites.
+but does not help you write well-architected test suites.
 In this chapter we offer advice, guidelines, and recommendations.
 on how to approach functional web page automation.
 

--- a/docs_source_files/content/guidelines_and_recommendations/_index.nl.md
+++ b/docs_source_files/content/guidelines_and_recommendations/_index.nl.md
@@ -15,17 +15,17 @@ it by sending us pull requests!
 
 A note on "Best Practices": We've intentionally avoided the phrase "Best
 Practices" in this documentation. No one approach works for all situations.
-We prefer the idea of "Guidelines and Recommendations." We encourage
+We prefer the idea of "Guidelines and Recommendations". We encourage
 you to read through these and thoughtfully decide what approaches
 will work for you in your particular environment.
 
 Functional testing is difficult to get right for many reasons.
-As if application state, complexity, and dependencies don't make testing difficult enough,
+As if application state, complexity, and dependencies do not make testing difficult enough,
 dealing with browsers (especially with cross-browser incompatibilities)
 makes writing good tests a challenge.
 
 Selenium provides tools to make functional user interaction easier,
-but doesn't help you write well-architected test suites.
+but does not help you write well-architected test suites.
 In this chapter we offer advice, guidelines, and recommendations.
 on how to approach functional web page automation.
 

--- a/docs_source_files/content/guidelines_and_recommendations/_index.zh-cn.md
+++ b/docs_source_files/content/guidelines_and_recommendations/_index.zh-cn.md
@@ -14,17 +14,17 @@ weight: 7
 
 A note on "Best Practices": We've intentionally avoided the phrase "Best
 Practices" in this documentation. No one approach works for all situations.
-We prefer the idea of "Guidelines and Recommendations." We encourage
+We prefer the idea of "Guidelines and Recommendations". We encourage
 you to read through these and thoughtfully decide what approaches
 will work for you in your particular environment.
 
 Functional testing is difficult to get right for many reasons.
-As if application state, complexity, and dependencies don't make testing difficult enough,
+As if application state, complexity, and dependencies do not make testing difficult enough,
 dealing with browsers (especially with cross-browser incompatibilities)
 makes writing good tests a challenge.
 
 Selenium provides tools to make functional user interaction easier,
-but doesn't help you write well-architected test suites.
+but does not help you write well-architected test suites.
 In this chapter we offer advice, guidelines, and recommendations.
 on how to approach functional web page automation.
 

--- a/docs_source_files/content/guidelines_and_recommendations/avoid_sharing_state.en.md
+++ b/docs_source_files/content/guidelines_and_recommendations/avoid_sharing_state.en.md
@@ -3,6 +3,7 @@ title: "Avoid sharing state"
 weight: 6
 ---
 
+
 Although mentioned in several places it is worth mentioning again. Ensure 
 tests are isolated from one another.
 

--- a/docs_source_files/content/guidelines_and_recommendations/avoid_sharing_state.es.md
+++ b/docs_source_files/content/guidelines_and_recommendations/avoid_sharing_state.es.md
@@ -12,12 +12,12 @@ it by sending us pull requests!
 Although mentioned in several places it is worth mentioning again. Ensure 
 tests are isolated from one another.
 
-Don't share test data. Imagine several tests that each query the database 
+* Do not share test data. Imagine several tests that each query the database 
 for valid orders before picking one to perform an action on. Should two tests
 pick up the same order you are likely to get unexpected behaviour.
 
-Clean up stale data in the application that might be picked up by another 
+* Clean up stale data in the application that might be picked up by another 
 test e.g. invalid order records.
 
-Create a new WebDriver instance per test. This helps ensure test isolation
+* Create a new WebDriver instance per test. This helps ensure test isolation
 and makes parallelisation simpler.

--- a/docs_source_files/content/guidelines_and_recommendations/avoid_sharing_state.fr.md
+++ b/docs_source_files/content/guidelines_and_recommendations/avoid_sharing_state.fr.md
@@ -12,12 +12,12 @@ it by sending us pull requests!
 Although mentioned in several places it is worth mentioning again. Ensure 
 tests are isolated from one another.
 
-Don't share test data. Imagine several tests that each query the database 
+* Do not share test data. Imagine several tests that each query the database 
 for valid orders before picking one to perform an action on. Should two tests
 pick up the same order you are likely to get unexpected behaviour.
 
-Clean up stale data in the application that might be picked up by another 
+* Clean up stale data in the application that might be picked up by another 
 test e.g. invalid order records.
 
-Create a new WebDriver instance per test. This helps ensure test isolation
+* Create a new WebDriver instance per test. This helps ensure test isolation
 and makes parallelisation simpler.

--- a/docs_source_files/content/guidelines_and_recommendations/avoid_sharing_state.ja.md
+++ b/docs_source_files/content/guidelines_and_recommendations/avoid_sharing_state.ja.md
@@ -8,15 +8,15 @@ weight: 6
 日本語は話せますか？プルリクエストをして翻訳を手伝ってください!
 {{% /notice %}}
 
-Although mentioned in several places it is worth mentioning again. Ensure
+Although mentioned in several places it is worth mentioning again. Ensure 
 tests are isolated from one another.
 
-Don't share test data. Imagine several tests that each query the database
+* Do not share test data. Imagine several tests that each query the database 
 for valid orders before picking one to perform an action on. Should two tests
 pick up the same order you are likely to get unexpected behaviour.
 
-Clean up stale data in the application that might be picked up by another
+* Clean up stale data in the application that might be picked up by another 
 test e.g. invalid order records.
 
-Create a new WebDriver instance per test. This helps ensure test isolation
+* Create a new WebDriver instance per test. This helps ensure test isolation
 and makes parallelisation simpler.

--- a/docs_source_files/content/guidelines_and_recommendations/avoid_sharing_state.nl.md
+++ b/docs_source_files/content/guidelines_and_recommendations/avoid_sharing_state.nl.md
@@ -12,12 +12,12 @@ it by sending us pull requests!
 Although mentioned in several places it is worth mentioning again. Ensure 
 tests are isolated from one another.
 
-Don't share test data. Imagine several tests that each query the database 
+* Do not share test data. Imagine several tests that each query the database 
 for valid orders before picking one to perform an action on. Should two tests
 pick up the same order you are likely to get unexpected behaviour.
 
-Clean up stale data in the application that might be picked up by another 
+* Clean up stale data in the application that might be picked up by another 
 test e.g. invalid order records.
 
-Create a new WebDriver instance per test. This helps ensure test isolation
+* Create a new WebDriver instance per test. This helps ensure test isolation
 and makes parallelisation simpler.

--- a/docs_source_files/content/guidelines_and_recommendations/avoid_sharing_state.zh-cn.md
+++ b/docs_source_files/content/guidelines_and_recommendations/avoid_sharing_state.zh-cn.md
@@ -8,15 +8,15 @@ weight: 6
 您熟悉英语与简体中文吗？帮助我们翻译它，通过 pull requests 给我们！
 {{% /notice %}}
 
-Although mentioned in several places it is worth mentioning again. Ensure
+Although mentioned in several places it is worth mentioning again. Ensure 
 tests are isolated from one another.
 
-Don't share test data. Imagine several tests that each query the database
+* Do not share test data. Imagine several tests that each query the database 
 for valid orders before picking one to perform an action on. Should two tests
 pick up the same order you are likely to get unexpected behaviour.
 
-Clean up stale data in the application that might be picked up by another
+* Clean up stale data in the application that might be picked up by another 
 test e.g. invalid order records.
 
-Create a new WebDriver instance per test. This helps ensure test isolation
+* Create a new WebDriver instance per test. This helps ensure test isolation
 and makes parallelisation simpler.

--- a/docs_source_files/content/guidelines_and_recommendations/consider_using_a_fluent_api.en.md
+++ b/docs_source_files/content/guidelines_and_recommendations/consider_using_a_fluent_api.en.md
@@ -3,6 +3,7 @@ title: "Consider using a fluent API"
 weight: 8
 ---
 
+
 Martin Fowler coined the term ["Fluent API"](//www.martinfowler.com/bliki/FluentInterface.html). Selenium already
 implements something like this in their `FluentWait` class, which is
 meant as an alternative to the standard <code>Wait</code> class. 

--- a/docs_source_files/content/guidelines_and_recommendations/consider_using_a_fluent_api.es.md
+++ b/docs_source_files/content/guidelines_and_recommendations/consider_using_a_fluent_api.es.md
@@ -9,8 +9,8 @@ English to Spanish. Do you speak Spanish? Help us to translate
 it by sending us pull requests!
 {{% /notice %}}
 
-Martin Fowler coined the term ["Fluent API"](//www.martinfowler.com/bliki/FluentInterface.html). 
-Selenium already implements something like this in their `FluentWait` class which is
+Martin Fowler coined the term ["Fluent API"](//www.martinfowler.com/bliki/FluentInterface.html). Selenium already
+implements something like this in their `FluentWait` class, which is
 meant as an alternative to the standard <code>Wait</code> class. 
 You could enable the Fluent API design pattern in your page object 
 and then query the Google search page with a code snippet like this one:

--- a/docs_source_files/content/guidelines_and_recommendations/consider_using_a_fluent_api.fr.md
+++ b/docs_source_files/content/guidelines_and_recommendations/consider_using_a_fluent_api.fr.md
@@ -9,8 +9,8 @@ English to French. Do you speak French? Help us to translate
 it by sending us pull requests!
 {{% /notice %}}
 
-Martin Fowler coined the term ["Fluent API"](//www.martinfowler.com/bliki/FluentInterface.html). 
-Selenium already implements something like this in their `FluentWait` class which is
+Martin Fowler coined the term ["Fluent API"](//www.martinfowler.com/bliki/FluentInterface.html). Selenium already
+implements something like this in their `FluentWait` class, which is
 meant as an alternative to the standard <code>Wait</code> class. 
 You could enable the Fluent API design pattern in your page object 
 and then query the Google search page with a code snippet like this one:

--- a/docs_source_files/content/guidelines_and_recommendations/consider_using_a_fluent_api.ja.md
+++ b/docs_source_files/content/guidelines_and_recommendations/consider_using_a_fluent_api.ja.md
@@ -8,10 +8,10 @@ weight: 8
 日本語は話せますか？プルリクエストをして翻訳を手伝ってください!
 {{% /notice %}}
 
-Martin Fowler coined the term ["Fluent API"](//www.martinfowler.com/bliki/FluentInterface.html). 
-Selenium already implements something like this in their `FluentWait` class which is
-meant as an alternative to the standard <code>Wait</code> class.
-You could enable the Fluent API design pattern in your page object
+Martin Fowler coined the term ["Fluent API"](//www.martinfowler.com/bliki/FluentInterface.html). Selenium already
+implements something like this in their `FluentWait` class, which is
+meant as an alternative to the standard <code>Wait</code> class. 
+You could enable the Fluent API design pattern in your page object 
 and then query the Google search page with a code snippet like this one:
 
 ```java

--- a/docs_source_files/content/guidelines_and_recommendations/consider_using_a_fluent_api.nl.md
+++ b/docs_source_files/content/guidelines_and_recommendations/consider_using_a_fluent_api.nl.md
@@ -9,8 +9,8 @@ English to Dutch. Do you speak Dutch? Help us to translate
 it by sending us pull requests!
 {{% /notice %}}
 
-Martin Fowler coined the term ["Fluent API"](//www.martinfowler.com/bliki/FluentInterface.html). 
-Selenium already implements something like this in their `FluentWait` class which is
+Martin Fowler coined the term ["Fluent API"](//www.martinfowler.com/bliki/FluentInterface.html). Selenium already
+implements something like this in their `FluentWait` class, which is
 meant as an alternative to the standard <code>Wait</code> class. 
 You could enable the Fluent API design pattern in your page object 
 and then query the Google search page with a code snippet like this one:

--- a/docs_source_files/content/guidelines_and_recommendations/consider_using_a_fluent_api.zh-cn.md
+++ b/docs_source_files/content/guidelines_and_recommendations/consider_using_a_fluent_api.zh-cn.md
@@ -8,10 +8,10 @@ weight: 8
 您熟悉英语与简体中文吗？帮助我们翻译它，通过 pull requests 给我们！
 {{% /notice %}}
 
-Martin Fowler coined the term ["Fluent API"](//www.martinfowler.com/bliki/FluentInterface.html). 
-Selenium already implements something like this in their `FluentWait` class which is
-meant as an alternative to the standard <code>Wait</code> class.
-You could enable the Fluent API design pattern in your page object
+Martin Fowler coined the term ["Fluent API"](//www.martinfowler.com/bliki/FluentInterface.html). Selenium already
+implements something like this in their `FluentWait` class, which is
+meant as an alternative to the standard <code>Wait</code> class. 
+You could enable the Fluent API design pattern in your page object 
 and then query the Google search page with a code snippet like this one:
 
 ```java

--- a/docs_source_files/content/guidelines_and_recommendations/domain_specific_language.es.md
+++ b/docs_source_files/content/guidelines_and_recommendations/domain_specific_language.es.md
@@ -13,15 +13,15 @@ A domain specific language (DSL) is a system which provides the user with
 an expressive means of solving a problem. It allows a user to
 interact with the system on their terms – not just programmer-speak.
 
-Your users, in general, don't care how your site looks. They don't
+Your users, in general, do not care how your site looks. They do not
 care about the decoration, animations, or graphics. They
 want to use your system to push their new employees through the
-process with minimal difficulty.  They want to book travel to Alaska.
-They want to configure and buy unicorns at a discount. Your job as the
+process with minimal difficulty; they want to book travel to Alaska; 
+they want to configure and buy unicorns at a discount. Your job as
 tester is to come as close as you can to “capturing” this mind-set.
-With that in mind, we set about “modeling” the application you're
+With that in mind, we set about “modeling” the application you are
 working on, such that the test scripts (the user's only pre-release
-proxy) “speak” for and represent the user.
+proxy) “speak” for, and represent the user.
 
 With Selenium, DSL is usually represented by methods, written to make
 the API simple and readable – they enable a report between the
@@ -35,7 +35,7 @@ intelligence specialists, etc.).
 * **Extensible:** Functionality can (reasonably) be added
   without breaking contracts and existing functionality.
 * **Maintainable:** By leaving the implementation details out of test
-  cases, you are well-insulated against changes to the AUT (application under test).
+  cases, you are well-insulated against changes to the AUT*.
 
 
 ## Java
@@ -71,7 +71,7 @@ public AccountPage loginAsUser(String username, String password) {
 
 This method completely abstracts the concepts of input fields,
 buttons, clicking, and even pages from your test code. Using this
-approach, all your tester has to do is call this method. This gives
+approach, all a tester has to do is call this method. This gives
 you a maintenance advantage: if the login fields ever changed, you
 would only ever have to change this method - not your tests.
 
@@ -93,9 +93,11 @@ public void loginTest() {
 It bears repeating: one of your primary goals should be writing an
 API that allows your tests to address **the problem at hand, and NOT
 the problem of the UI**. The UI is a secondary concern for your
-users – they don't care about the UI, they just want to get their job
+users – they do not care about the UI, they just want to get their job
 done. Your test scripts should read like a laundry list of things
 the user wants to DO, and the things they want to KNOW. The tests
 should not concern themselves with HOW the UI requires you to go
 about it.
+
+***AUT**: Application under test
 

--- a/docs_source_files/content/guidelines_and_recommendations/domain_specific_language.fr.md
+++ b/docs_source_files/content/guidelines_and_recommendations/domain_specific_language.fr.md
@@ -13,15 +13,15 @@ A domain specific language (DSL) is a system which provides the user with
 an expressive means of solving a problem. It allows a user to
 interact with the system on their terms – not just programmer-speak.
 
-Your users, in general, don't care how your site looks. They don't
+Your users, in general, do not care how your site looks. They do not
 care about the decoration, animations, or graphics. They
 want to use your system to push their new employees through the
-process with minimal difficulty.  They want to book travel to Alaska.
-They want to configure and buy unicorns at a discount. Your job as the
+process with minimal difficulty; they want to book travel to Alaska; 
+they want to configure and buy unicorns at a discount. Your job as
 tester is to come as close as you can to “capturing” this mind-set.
-With that in mind, we set about “modeling” the application you're
+With that in mind, we set about “modeling” the application you are
 working on, such that the test scripts (the user's only pre-release
-proxy) “speak” for and represent the user.
+proxy) “speak” for, and represent the user.
 
 With Selenium, DSL is usually represented by methods, written to make
 the API simple and readable – they enable a report between the
@@ -35,7 +35,7 @@ intelligence specialists, etc.).
 * **Extensible:** Functionality can (reasonably) be added
   without breaking contracts and existing functionality.
 * **Maintainable:** By leaving the implementation details out of test
-  cases, you are well-insulated against changes to the AUT (application under test).
+  cases, you are well-insulated against changes to the AUT*.
 
 
 ## Java
@@ -71,7 +71,7 @@ public AccountPage loginAsUser(String username, String password) {
 
 This method completely abstracts the concepts of input fields,
 buttons, clicking, and even pages from your test code. Using this
-approach, all your tester has to do is call this method. This gives
+approach, all a tester has to do is call this method. This gives
 you a maintenance advantage: if the login fields ever changed, you
 would only ever have to change this method - not your tests.
 
@@ -93,9 +93,11 @@ public void loginTest() {
 It bears repeating: one of your primary goals should be writing an
 API that allows your tests to address **the problem at hand, and NOT
 the problem of the UI**. The UI is a secondary concern for your
-users – they don't care about the UI, they just want to get their job
+users – they do not care about the UI, they just want to get their job
 done. Your test scripts should read like a laundry list of things
 the user wants to DO, and the things they want to KNOW. The tests
 should not concern themselves with HOW the UI requires you to go
 about it.
+
+***AUT**: Application under test
 

--- a/docs_source_files/content/guidelines_and_recommendations/domain_specific_language.ja.md
+++ b/docs_source_files/content/guidelines_and_recommendations/domain_specific_language.ja.md
@@ -12,15 +12,15 @@ A domain specific language (DSL) is a system which provides the user with
 an expressive means of solving a problem. It allows a user to
 interact with the system on their terms – not just programmer-speak.
 
-Your users, in general, don't care how your site looks. They don't
+Your users, in general, do not care how your site looks. They do not
 care about the decoration, animations, or graphics. They
 want to use your system to push their new employees through the
-process with minimal difficulty.  They want to book travel to Alaska.
-They want to configure and buy unicorns at a discount. Your job as the
+process with minimal difficulty; they want to book travel to Alaska; 
+they want to configure and buy unicorns at a discount. Your job as
 tester is to come as close as you can to “capturing” this mind-set.
-With that in mind, we set about “modeling” the application you're
+With that in mind, we set about “modeling” the application you are
 working on, such that the test scripts (the user's only pre-release
-proxy) “speak” for and represent the user.
+proxy) “speak” for, and represent the user.
 
 With Selenium, DSL is usually represented by methods, written to make
 the API simple and readable – they enable a report between the
@@ -34,7 +34,7 @@ intelligence specialists, etc.).
 * **Extensible:** Functionality can (reasonably) be added
   without breaking contracts and existing functionality.
 * **Maintainable:** By leaving the implementation details out of test
-  cases, you are well-insulated against changes to the AUT (application under test).
+  cases, you are well-insulated against changes to the AUT*.
 
 
 ## Java
@@ -70,7 +70,7 @@ public AccountPage loginAsUser(String username, String password) {
 
 This method completely abstracts the concepts of input fields,
 buttons, clicking, and even pages from your test code. Using this
-approach, all your tester has to do is call this method. This gives
+approach, all a tester has to do is call this method. This gives
 you a maintenance advantage: if the login fields ever changed, you
 would only ever have to change this method - not your tests.
 
@@ -92,8 +92,11 @@ public void loginTest() {
 It bears repeating: one of your primary goals should be writing an
 API that allows your tests to address **the problem at hand, and NOT
 the problem of the UI**. The UI is a secondary concern for your
-users – they don't care about the UI, they just want to get their job
+users – they do not care about the UI, they just want to get their job
 done. Your test scripts should read like a laundry list of things
 the user wants to DO, and the things they want to KNOW. The tests
 should not concern themselves with HOW the UI requires you to go
 about it.
+
+***AUT**: Application under test
+

--- a/docs_source_files/content/guidelines_and_recommendations/domain_specific_language.nl.md
+++ b/docs_source_files/content/guidelines_and_recommendations/domain_specific_language.nl.md
@@ -13,15 +13,15 @@ A domain specific language (DSL) is a system which provides the user with
 an expressive means of solving a problem. It allows a user to
 interact with the system on their terms – not just programmer-speak.
 
-Your users, in general, don't care how your site looks. They don't
+Your users, in general, do not care how your site looks. They do not
 care about the decoration, animations, or graphics. They
 want to use your system to push their new employees through the
-process with minimal difficulty.  They want to book travel to Alaska.
-They want to configure and buy unicorns at a discount. Your job as the
+process with minimal difficulty; they want to book travel to Alaska; 
+they want to configure and buy unicorns at a discount. Your job as
 tester is to come as close as you can to “capturing” this mind-set.
-With that in mind, we set about “modeling” the application you're
+With that in mind, we set about “modeling” the application you are
 working on, such that the test scripts (the user's only pre-release
-proxy) “speak” for and represent the user.
+proxy) “speak” for, and represent the user.
 
 With Selenium, DSL is usually represented by methods, written to make
 the API simple and readable – they enable a report between the
@@ -35,7 +35,7 @@ intelligence specialists, etc.).
 * **Extensible:** Functionality can (reasonably) be added
   without breaking contracts and existing functionality.
 * **Maintainable:** By leaving the implementation details out of test
-  cases, you are well-insulated against changes to the AUT (application under test).
+  cases, you are well-insulated against changes to the AUT*.
 
 
 ## Java
@@ -71,7 +71,7 @@ public AccountPage loginAsUser(String username, String password) {
 
 This method completely abstracts the concepts of input fields,
 buttons, clicking, and even pages from your test code. Using this
-approach, all your tester has to do is call this method. This gives
+approach, all a tester has to do is call this method. This gives
 you a maintenance advantage: if the login fields ever changed, you
 would only ever have to change this method - not your tests.
 
@@ -93,9 +93,11 @@ public void loginTest() {
 It bears repeating: one of your primary goals should be writing an
 API that allows your tests to address **the problem at hand, and NOT
 the problem of the UI**. The UI is a secondary concern for your
-users – they don't care about the UI, they just want to get their job
+users – they do not care about the UI, they just want to get their job
 done. Your test scripts should read like a laundry list of things
 the user wants to DO, and the things they want to KNOW. The tests
 should not concern themselves with HOW the UI requires you to go
 about it.
+
+***AUT**: Application under test
 

--- a/docs_source_files/content/guidelines_and_recommendations/domain_specific_language.zh-cn.md
+++ b/docs_source_files/content/guidelines_and_recommendations/domain_specific_language.zh-cn.md
@@ -12,15 +12,15 @@ A domain specific language (DSL) is a system which provides the user with
 an expressive means of solving a problem. It allows a user to
 interact with the system on their terms – not just programmer-speak.
 
-Your users, in general, don't care how your site looks. They don't
+Your users, in general, do not care how your site looks. They do not
 care about the decoration, animations, or graphics. They
 want to use your system to push their new employees through the
-process with minimal difficulty.  They want to book travel to Alaska.
-They want to configure and buy unicorns at a discount. Your job as the
+process with minimal difficulty; they want to book travel to Alaska; 
+they want to configure and buy unicorns at a discount. Your job as
 tester is to come as close as you can to “capturing” this mind-set.
-With that in mind, we set about “modeling” the application you're
+With that in mind, we set about “modeling” the application you are
 working on, such that the test scripts (the user's only pre-release
-proxy) “speak” for and represent the user.
+proxy) “speak” for, and represent the user.
 
 With Selenium, DSL is usually represented by methods, written to make
 the API simple and readable – they enable a report between the
@@ -34,7 +34,7 @@ intelligence specialists, etc.).
 * **Extensible:** Functionality can (reasonably) be added
   without breaking contracts and existing functionality.
 * **Maintainable:** By leaving the implementation details out of test
-  cases, you are well-insulated against changes to the AUT (application under test).
+  cases, you are well-insulated against changes to the AUT*.
 
 
 ## Java
@@ -70,7 +70,7 @@ public AccountPage loginAsUser(String username, String password) {
 
 This method completely abstracts the concepts of input fields,
 buttons, clicking, and even pages from your test code. Using this
-approach, all your tester has to do is call this method. This gives
+approach, all a tester has to do is call this method. This gives
 you a maintenance advantage: if the login fields ever changed, you
 would only ever have to change this method - not your tests.
 
@@ -92,9 +92,11 @@ public void loginTest() {
 It bears repeating: one of your primary goals should be writing an
 API that allows your tests to address **the problem at hand, and NOT
 the problem of the UI**. The UI is a secondary concern for your
-users – they don't care about the UI, they just want to get their job
+users – they do not care about the UI, they just want to get their job
 done. Your test scripts should read like a laundry list of things
 the user wants to DO, and the things they want to KNOW. The tests
 should not concern themselves with HOW the UI requires you to go
 about it.
+
+***AUT**: Application under test
 

--- a/docs_source_files/content/guidelines_and_recommendations/generating_application_state.es.md
+++ b/docs_source_files/content/guidelines_and_recommendations/generating_application_state.es.md
@@ -10,11 +10,13 @@ it by sending us pull requests!
 {{% /notice %}}
 
 Selenium should not be used to prepare a test case.  All repetitive
-actions, and preparation for a test case, should be done through other
+actions and preparations for a test case, should be done through other
 methods.  For example, most web UIs have authentication (e.g. a login
 form). Eliminating logging in via web browser before every test will
 improve both the speed and stability of the test. A method should be
-created to gain access to the AUT (e.g. using an API to login and set a
+created to gain access to the AUT* (e.g. using an API to login and set a
 cookie).  Also, creating methods to pre-load data for
 testing should not be done using Selenium.  As mentioned previously,
-existing APIs should be leveraged to create data for the AUT.
+existing APIs should be leveraged to create data for the AUT*.
+
+***AUT**: Application under test

--- a/docs_source_files/content/guidelines_and_recommendations/generating_application_state.fr.md
+++ b/docs_source_files/content/guidelines_and_recommendations/generating_application_state.fr.md
@@ -10,11 +10,13 @@ it by sending us pull requests!
 {{% /notice %}}
 
 Selenium should not be used to prepare a test case.  All repetitive
-actions, and preparation for a test case, should be done through other
+actions and preparations for a test case, should be done through other
 methods.  For example, most web UIs have authentication (e.g. a login
 form). Eliminating logging in via web browser before every test will
 improve both the speed and stability of the test. A method should be
-created to gain access to the AUT (e.g. using an API to login and set a
+created to gain access to the AUT* (e.g. using an API to login and set a
 cookie).  Also, creating methods to pre-load data for
 testing should not be done using Selenium.  As mentioned previously,
-existing APIs should be leveraged to create data for the AUT.
+existing APIs should be leveraged to create data for the AUT*.
+
+***AUT**: Application under test

--- a/docs_source_files/content/guidelines_and_recommendations/generating_application_state.ja.md
+++ b/docs_source_files/content/guidelines_and_recommendations/generating_application_state.ja.md
@@ -9,11 +9,13 @@ weight: 3
 {{% /notice %}}
 
 Selenium should not be used to prepare a test case.  All repetitive
-actions, and preparation for a test case, should be done through other
+actions and preparations for a test case, should be done through other
 methods.  For example, most web UIs have authentication (e.g. a login
 form). Eliminating logging in via web browser before every test will
 improve both the speed and stability of the test. A method should be
-created to gain access to the AUT (e.g. using an API to login and set a
+created to gain access to the AUT* (e.g. using an API to login and set a
 cookie).  Also, creating methods to pre-load data for
 testing should not be done using Selenium.  As mentioned previously,
-existing APIs should be leveraged to create data for the AUT.
+existing APIs should be leveraged to create data for the AUT*.
+
+***AUT**: Application under test

--- a/docs_source_files/content/guidelines_and_recommendations/generating_application_state.nl.md
+++ b/docs_source_files/content/guidelines_and_recommendations/generating_application_state.nl.md
@@ -10,11 +10,13 @@ it by sending us pull requests!
 {{% /notice %}}
 
 Selenium should not be used to prepare a test case.  All repetitive
-actions, and preparation for a test case, should be done through other
+actions and preparations for a test case, should be done through other
 methods.  For example, most web UIs have authentication (e.g. a login
 form). Eliminating logging in via web browser before every test will
 improve both the speed and stability of the test. A method should be
-created to gain access to the AUT (e.g. using an API to login and set a
+created to gain access to the AUT* (e.g. using an API to login and set a
 cookie).  Also, creating methods to pre-load data for
 testing should not be done using Selenium.  As mentioned previously,
-existing APIs should be leveraged to create data for the AUT.
+existing APIs should be leveraged to create data for the AUT*.
+
+***AUT**: Application under test

--- a/docs_source_files/content/guidelines_and_recommendations/generating_application_state.zh-cn.md
+++ b/docs_source_files/content/guidelines_and_recommendations/generating_application_state.zh-cn.md
@@ -9,11 +9,13 @@ weight: 3
 {{% /notice %}}
 
 Selenium should not be used to prepare a test case.  All repetitive
-actions, and preparation for a test case, should be done through other
+actions and preparations for a test case, should be done through other
 methods.  For example, most web UIs have authentication (e.g. a login
 form). Eliminating logging in via web browser before every test will
 improve both the speed and stability of the test. A method should be
-created to gain access to the AUT (e.g. using an API to login and set a
+created to gain access to the AUT* (e.g. using an API to login and set a
 cookie).  Also, creating methods to pre-load data for
 testing should not be done using Selenium.  As mentioned previously,
-existing APIs should be leveraged to create data for the AUT.
+existing APIs should be leveraged to create data for the AUT*.
+
+***AUT**: Application under test

--- a/docs_source_files/content/guidelines_and_recommendations/improved_reporting.es.md
+++ b/docs_source_files/content/guidelines_and_recommendations/improved_reporting.es.md
@@ -18,3 +18,7 @@ reports are popular for importing results to a Continuous Integration
 for more information regarding report outputs for several languages.
 <!-- TODO: Add links.-->
 [NUnit 3 Console Runner](//github.com/nunit/docs/wiki/Console-Runner)
+[NUnit 3 Console Command Line](//github.com/nunit/docs/wiki/Console-Command-Line)
+[xUnit getting test results in TeamCity](//xunit.net/docs/getting-test-results-in-teamcity)
+[xUnit getting test results in CruiseControl.NET](//xunit.net/docs/getting-test-results-in-ccnet)
+[xUnit getting test results in Azure DevOps](//xunit.net/docs/getting-test-results-in-azure-devops)

--- a/docs_source_files/content/guidelines_and_recommendations/improved_reporting.fr.md
+++ b/docs_source_files/content/guidelines_and_recommendations/improved_reporting.fr.md
@@ -18,3 +18,7 @@ reports are popular for importing results to a Continuous Integration
 for more information regarding report outputs for several languages.
 <!-- TODO: Add links.-->
 [NUnit 3 Console Runner](//github.com/nunit/docs/wiki/Console-Runner)
+[NUnit 3 Console Command Line](//github.com/nunit/docs/wiki/Console-Command-Line)
+[xUnit getting test results in TeamCity](//xunit.net/docs/getting-test-results-in-teamcity)
+[xUnit getting test results in CruiseControl.NET](//xunit.net/docs/getting-test-results-in-ccnet)
+[xUnit getting test results in Azure DevOps](//xunit.net/docs/getting-test-results-in-azure-devops)

--- a/docs_source_files/content/guidelines_and_recommendations/improved_reporting.ja.md
+++ b/docs_source_files/content/guidelines_and_recommendations/improved_reporting.ja.md
@@ -17,3 +17,7 @@ reports are popular for importing results to a Continuous Integration
 for more information regarding report outputs for several languages.
 <!-- TODO: Add links.-->
 [NUnit 3 Console Runner](//github.com/nunit/docs/wiki/Console-Runner)
+[NUnit 3 Console Command Line](//github.com/nunit/docs/wiki/Console-Command-Line)
+[xUnit getting test results in TeamCity](//xunit.net/docs/getting-test-results-in-teamcity)
+[xUnit getting test results in CruiseControl.NET](//xunit.net/docs/getting-test-results-in-ccnet)
+[xUnit getting test results in Azure DevOps](//xunit.net/docs/getting-test-results-in-azure-devops)

--- a/docs_source_files/content/guidelines_and_recommendations/improved_reporting.nl.md
+++ b/docs_source_files/content/guidelines_and_recommendations/improved_reporting.nl.md
@@ -18,3 +18,7 @@ reports are popular for importing results to a Continuous Integration
 for more information regarding report outputs for several languages.
 <!-- TODO: Add links.-->
 [NUnit 3 Console Runner](//github.com/nunit/docs/wiki/Console-Runner)
+[NUnit 3 Console Command Line](//github.com/nunit/docs/wiki/Console-Command-Line)
+[xUnit getting test results in TeamCity](//xunit.net/docs/getting-test-results-in-teamcity)
+[xUnit getting test results in CruiseControl.NET](//xunit.net/docs/getting-test-results-in-ccnet)
+[xUnit getting test results in Azure DevOps](//xunit.net/docs/getting-test-results-in-azure-devops)

--- a/docs_source_files/content/guidelines_and_recommendations/improved_reporting.zh-cn.md
+++ b/docs_source_files/content/guidelines_and_recommendations/improved_reporting.zh-cn.md
@@ -17,3 +17,7 @@ reports are popular for importing results to a Continuous Integration
 for more information regarding report outputs for several languages.
 <!-- TODO: Add links.-->
 [NUnit 3 Console Runner](//github.com/nunit/docs/wiki/Console-Runner)
+[NUnit 3 Console Command Line](//github.com/nunit/docs/wiki/Console-Command-Line)
+[xUnit getting test results in TeamCity](//xunit.net/docs/getting-test-results-in-teamcity)
+[xUnit getting test results in CruiseControl.NET](//xunit.net/docs/getting-test-results-in-ccnet)
+[xUnit getting test results in Azure DevOps](//xunit.net/docs/getting-test-results-in-azure-devops)

--- a/docs_source_files/content/guidelines_and_recommendations/page_object_models.es.md
+++ b/docs_source_files/content/guidelines_and_recommendations/page_object_models.es.md
@@ -12,16 +12,16 @@ it by sending us pull requests!
 Page Object is a Design Pattern which has become popular in test
 automation for enhancing test maintenance and reducing code
 duplication. A page object is an object-oriented class that serves as
-an interface to a page of your AUT. The tests then use the methods of
+an interface to a page of your AUT*. The tests then use the methods of
 this page object class whenever they need to interact with that page
 of the UI. The benefit is that if the UI changes for the page, the
-tests themselves don’t need to change; only the code within the page
+tests themselves do not need to change; only the code within the page
 object needs to change. Subsequently, all changes to support that new
 UI are located in one place.
 
 The Page Object Design Pattern provides the following advantage:
 there is clean separation between test code and page specific code
-such as locators (or their use if you’re using a UI map) and layout.
+such as locators (or their use if you are using a UI map) and layout.
 
 
 ## Page object methods should return a value
@@ -31,3 +31,7 @@ such as locators (or their use if you’re using a UI map) and layout.
 * If you click submit on login
   and you want to check to see if a user is logged in,
   it should return True or False in a method.
+  
+
+  ***AUT**: Application under test
+

--- a/docs_source_files/content/guidelines_and_recommendations/page_object_models.fr.md
+++ b/docs_source_files/content/guidelines_and_recommendations/page_object_models.fr.md
@@ -12,16 +12,16 @@ it by sending us pull requests!
 Page Object is a Design Pattern which has become popular in test
 automation for enhancing test maintenance and reducing code
 duplication. A page object is an object-oriented class that serves as
-an interface to a page of your AUT. The tests then use the methods of
+an interface to a page of your AUT*. The tests then use the methods of
 this page object class whenever they need to interact with that page
 of the UI. The benefit is that if the UI changes for the page, the
-tests themselves don’t need to change; only the code within the page
+tests themselves do not need to change; only the code within the page
 object needs to change. Subsequently, all changes to support that new
 UI are located in one place.
 
 The Page Object Design Pattern provides the following advantage:
 there is clean separation between test code and page specific code
-such as locators (or their use if you’re using a UI map) and layout.
+such as locators (or their use if you are using a UI map) and layout.
 
 
 ## Page object methods should return a value
@@ -31,3 +31,7 @@ such as locators (or their use if you’re using a UI map) and layout.
 * If you click submit on login
   and you want to check to see if a user is logged in,
   it should return True or False in a method.
+  
+
+  ***AUT**: Application under test
+

--- a/docs_source_files/content/guidelines_and_recommendations/page_object_models.ja.md
+++ b/docs_source_files/content/guidelines_and_recommendations/page_object_models.ja.md
@@ -11,16 +11,16 @@ weight: 1
 Page Object is a Design Pattern which has become popular in test
 automation for enhancing test maintenance and reducing code
 duplication. A page object is an object-oriented class that serves as
-an interface to a page of your AUT. The tests then use the methods of
+an interface to a page of your AUT*. The tests then use the methods of
 this page object class whenever they need to interact with that page
 of the UI. The benefit is that if the UI changes for the page, the
-tests themselves don’t need to change; only the code within the page
+tests themselves do not need to change; only the code within the page
 object needs to change. Subsequently, all changes to support that new
 UI are located in one place.
 
 The Page Object Design Pattern provides the following advantage:
 there is clean separation between test code and page specific code
-such as locators (or their use if you’re using a UI map) and layout.
+such as locators (or their use if you are using a UI map) and layout.
 
 
 ## Page object methods should return a value
@@ -30,3 +30,7 @@ such as locators (or their use if you’re using a UI map) and layout.
 * If you click submit on login
   and you want to check to see if a user is logged in,
   it should return True or False in a method.
+  
+
+  ***AUT**: Application under test
+

--- a/docs_source_files/content/guidelines_and_recommendations/page_object_models.nl.md
+++ b/docs_source_files/content/guidelines_and_recommendations/page_object_models.nl.md
@@ -12,16 +12,16 @@ it by sending us pull requests!
 Page Object is a Design Pattern which has become popular in test
 automation for enhancing test maintenance and reducing code
 duplication. A page object is an object-oriented class that serves as
-an interface to a page of your AUT. The tests then use the methods of
+an interface to a page of your AUT*. The tests then use the methods of
 this page object class whenever they need to interact with that page
 of the UI. The benefit is that if the UI changes for the page, the
-tests themselves don’t need to change; only the code within the page
+tests themselves do not need to change; only the code within the page
 object needs to change. Subsequently, all changes to support that new
 UI are located in one place.
 
 The Page Object Design Pattern provides the following advantage:
 there is clean separation between test code and page specific code
-such as locators (or their use if you’re using a UI map) and layout.
+such as locators (or their use if you are using a UI map) and layout.
 
 
 ## Page object methods should return a value
@@ -31,3 +31,7 @@ such as locators (or their use if you’re using a UI map) and layout.
 * If you click submit on login
   and you want to check to see if a user is logged in,
   it should return True or False in a method.
+  
+
+  ***AUT**: Application under test
+

--- a/docs_source_files/content/guidelines_and_recommendations/page_object_models.zh-cn.md
+++ b/docs_source_files/content/guidelines_and_recommendations/page_object_models.zh-cn.md
@@ -11,16 +11,16 @@ weight: 1
 Page Object is a Design Pattern which has become popular in test
 automation for enhancing test maintenance and reducing code
 duplication. A page object is an object-oriented class that serves as
-an interface to a page of your AUT. The tests then use the methods of
+an interface to a page of your AUT*. The tests then use the methods of
 this page object class whenever they need to interact with that page
 of the UI. The benefit is that if the UI changes for the page, the
-tests themselves don’t need to change; only the code within the page
+tests themselves do not need to change; only the code within the page
 object needs to change. Subsequently, all changes to support that new
 UI are located in one place.
 
 The Page Object Design Pattern provides the following advantage:
 there is clean separation between test code and page specific code
-such as locators (or their use if you’re using a UI map) and layout.
+such as locators (or their use if you are using a UI map) and layout.
 
 
 ## Page object methods should return a value
@@ -30,3 +30,7 @@ such as locators (or their use if you’re using a UI map) and layout.
 * If you click submit on login
   and you want to check to see if a user is logged in,
   it should return True or False in a method.
+  
+
+  ***AUT**: Application under test
+

--- a/docs_source_files/content/guidelines_and_recommendations/test_independency.en.md
+++ b/docs_source_files/content/guidelines_and_recommendations/test_independency.en.md
@@ -3,6 +3,7 @@ title: "Test independency"
 weight: 7
 ---
 
+
 Write each test as its own unit. Write the tests in a way that will not be
 reliant on other tests to complete:
 

--- a/docs_source_files/content/guidelines_and_recommendations/test_independency.es.md
+++ b/docs_source_files/content/guidelines_and_recommendations/test_independency.es.md
@@ -9,10 +9,10 @@ English to Spanish. Do you speak Spanish? Help us to translate
 it by sending us pull requests!
 {{% /notice %}}
 
-Write each test as its own unit. Write the tests in a way that won't be
+Write each test as its own unit. Write the tests in a way that will not be
 reliant on other tests to complete:
 
-Let's say there is a content management system with which you can create
+Let us say there is a content management system with which you can create
 some custom content which then appears on your website as a module after 
 publishing, and it may take some time to sync between the CMS and the 
 application.

--- a/docs_source_files/content/guidelines_and_recommendations/test_independency.fr.md
+++ b/docs_source_files/content/guidelines_and_recommendations/test_independency.fr.md
@@ -9,10 +9,10 @@ English to French. Do you speak French? Help us to translate
 it by sending us pull requests!
 {{% /notice %}}
 
-Write each test as its own unit. Write the tests in a way that won't be
+Write each test as its own unit. Write the tests in a way that will not be
 reliant on other tests to complete:
 
-Let's say there is a content management system with which you can create
+Let us say there is a content management system with which you can create
 some custom content which then appears on your website as a module after 
 publishing, and it may take some time to sync between the CMS and the 
 application.

--- a/docs_source_files/content/guidelines_and_recommendations/test_independency.ja.md
+++ b/docs_source_files/content/guidelines_and_recommendations/test_independency.ja.md
@@ -8,19 +8,19 @@ weight: 7
 日本語は話せますか？プルリクエストをして翻訳を手伝ってください!
 {{% /notice %}}
 
-Write each test as its own unit. Write the tests in a way that won't be
+Write each test as its own unit. Write the tests in a way that will not be
 reliant on other tests to complete:
 
-Let's say there is a content management system with which you can create
-some custom content which then appears on your website as a module after
-publishing, and it may take some time to sync between the CMS and the
+Let us say there is a content management system with which you can create
+some custom content which then appears on your website as a module after 
+publishing, and it may take some time to sync between the CMS and the 
 application.
 
-A wrong way of testing your module is that the content is created and
-published in one test, and then checking the module in another test. This
-is not feasible as the content may not be available immediately for the
+A wrong way of testing your module is that the content is created and 
+published in one test, and then checking the module in another test. This 
+is not feasible as the content may not be available immediately for the 
 other test after publishing.
 
-Instead, you can create a stub content which can be turned on and off
+Instead, you can create a stub content which can be turned on and off 
 within the affected test, and use that for validating the module. However,
 for content creation, you can still have a separate test.

--- a/docs_source_files/content/guidelines_and_recommendations/test_independency.nl.md
+++ b/docs_source_files/content/guidelines_and_recommendations/test_independency.nl.md
@@ -9,10 +9,10 @@ English to Dutch. Do you speak Dutch? Help us to translate
 it by sending us pull requests!
 {{% /notice %}}
 
-Write each test as its own unit. Write the tests in a way that won't be
+Write each test as its own unit. Write the tests in a way that will not be
 reliant on other tests to complete:
 
-Let's say there is a content management system with which you can create
+Let us say there is a content management system with which you can create
 some custom content which then appears on your website as a module after 
 publishing, and it may take some time to sync between the CMS and the 
 application.

--- a/docs_source_files/content/guidelines_and_recommendations/test_independency.zh-cn.md
+++ b/docs_source_files/content/guidelines_and_recommendations/test_independency.zh-cn.md
@@ -8,19 +8,19 @@ weight: 7
 您熟悉英语与简体中文吗？帮助我们翻译它，通过 pull requests 给我们！
 {{% /notice %}}
 
-Write each test as its own unit. Write the tests in a way that won't be
+Write each test as its own unit. Write the tests in a way that will not be
 reliant on other tests to complete:
 
-Let's say there is a content management system with which you can create
-some custom content which then appears on your website as a module after
-publishing, and it may take some time to sync between the CMS and the
+Let us say there is a content management system with which you can create
+some custom content which then appears on your website as a module after 
+publishing, and it may take some time to sync between the CMS and the 
 application.
 
-A wrong way of testing your module is that the content is created and
-published in one test, and then checking the module in another test. This
-is not feasible as the content may not be available immediately for the
+A wrong way of testing your module is that the content is created and 
+published in one test, and then checking the module in another test. This 
+is not feasible as the content may not be available immediately for the 
 other test after publishing.
 
-Instead, you can create a stub content which can be turned on and off
+Instead, you can create a stub content which can be turned on and off 
 within the affected test, and use that for validating the module. However,
 for content creation, you can still have a separate test.

--- a/docs_source_files/themes/hugo-theme-learn/layouts/partials/header.html
+++ b/docs_source_files/themes/hugo-theme-learn/layouts/partials/header.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    {{ hugo.Generator }}
     {{ partial "meta.html" . }}
     {{ partial "favicon.html" . }}
     <title>{{ .Title }} :: {{ .Site.Title }}</title>


### PR DESCRIPTION
As already mentioned, I get a parser error and cannot start hugo server.

`
boris@xxxx:~/repos/selenium/site/docs_source_files$ hugo server
Error: "xxxxx/repos/selenium/site/docs_source_files/themes/hugo-theme-learn/layouts/partials/header.html:6:1": parse failed: template: partials/header.html:6: function "hugo" not defined
`

When I remove the line, everything is fine on my machine (ubuntu)
